### PR TITLE
Support setting of Link object paths. Make Manager and ComputerSystem dynamic.  

### DIFF
--- a/api_emulator/redfish/ComputerSystem/ResetActionInfo_api.py
+++ b/api_emulator/redfish/ComputerSystem/ResetActionInfo_api.py
@@ -1,0 +1,51 @@
+# Copyright Notice:
+# Copyright 2016 Distributed Management Task Force, Inc. All rights reserved.
+# License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/Redfish-Interface-Emulator/LICENSE.md
+
+# Singleton API: GET
+
+import g
+
+import sys, traceback
+from flask import Flask, request, make_response, render_template
+from flask_restful import reqparse, Api, Resource
+
+from .ResetActionInfo_template import get_ResetActionInfo_instance
+
+config = {}
+INTERNAL_ERROR = 500
+
+class ResetActionInfo_API(Resource):
+    # kwargs is use to pass in the wildcards values to replace when the instance is created.
+    def __init__(self, **kwargs):
+        print ('ResetActionInfoAPI init called')
+        print (kwargs)
+#        sw_id = kwargs['{sw_id}']
+        try:
+            global config
+            config=get_ResetActionInfo_instance(kwargs)
+            resp = config, 200
+        except Exception:
+            traceback.print_exc()
+            resp = INTERNAL_ERROR
+        print ('init exit')
+
+    # HTTP GET
+    def get(self):
+        try:
+            global config
+            resp = config, 200
+        except Exception:
+            traceback.print_exc()
+            resp = INTERNAL_ERROR
+        return resp
+
+    # HTTP PATCH
+
+    # HTTP PUT
+    def put(self):
+         return 'PUT is not a valid command', 202
+
+    # HTTP DELETE
+    def delete(self):
+         return 'DELETE is not a valid command', 202

--- a/api_emulator/redfish/ComputerSystem/ResetActionInfo_template.py
+++ b/api_emulator/redfish/ComputerSystem/ResetActionInfo_template.py
@@ -1,0 +1,36 @@
+# Copyright Notice:
+# Copyright 2016 Distributed Management Task Force, Inc. All rights reserved.
+# License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/Redfish-Interface-Emulator/LICENSE.md
+
+import copy
+
+_TEMPLATE = \
+{
+	"@Redfish.Copyright": "Copyright 2014-2016 Distributed Management Task Force, Inc. (DMTF). All rights reserved.",
+	"@odata.context": "{rb}$metadata#ActionInfo.ActionInfo",
+	"@odata.id": "{rb}Systems/{sys_id}/ResetActionInfo",
+	"@odata.type": "#ActionInfo.v1_0_0.ActionInfo",
+	"Parameters": [{
+		"Name": "ResetType",
+		"Required": "true",
+		"DataType": "String",
+		"AllowableValues": [
+			"On",
+			"ForceOff",
+			"GracefulShutdown",
+			"GracefulRestart",
+			"ForceRestart",
+			"Nmi",
+			"ForceOn",
+			"PushPowerButton"
+		]
+	}]
+}
+def get_ResetActionInfo_instance(wildcards):
+
+    c = copy.deepcopy(_TEMPLATE)
+
+    c['@odata.context']=c['@odata.context'].format(**wildcards)
+    c['@odata.id']=c['@odata.id'].format(**wildcards)
+
+    return c

--- a/api_emulator/redfish/ComputerSystem/ResetAction_api.py
+++ b/api_emulator/redfish/ComputerSystem/ResetAction_api.py
@@ -1,0 +1,49 @@
+# Copyright Notice:
+# Copyright 2016 Distributed Management Task Force, Inc. All rights reserved.
+# License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/Redfish-Interface-Emulator/LICENSE.md
+
+# Singleton API: POST
+
+import g
+import requests
+import os
+import subprocess
+import time
+
+import sys, traceback
+from flask import Flask, request, make_response, render_template
+from flask_restful import reqparse, Api, Resource
+from subprocess import check_output
+config = {}
+INTERNAL_ERROR = 500
+
+class ResetAction_API(Resource):
+    # kwargs is use to pass in the wildcards values to replace when the instance is created.
+    def __init__(self, **kwargs):
+        print ('ResetActionAPI init called')
+        print ('init exit')
+
+    # HTTP POST
+    def post(self):
+        print ('POST ActionInfoReset called')
+#        cli= "ssh cumulus@10.223.197.159 sudo reboot"
+#        clioutput = subprocess.call(cli, shell=True)
+#        print (clioutput)
+        print ('Reboot in progress')
+        return 'POST request completed', 200
+
+    # HTTP GET
+    def get(self):
+       return 'GET is not supported', 405, {'Allow': 'POST'}
+
+    # HTTP PATCH
+    def patch(self):
+         return 'PATCH is not supported', 405, {'Allow': 'POST'}
+
+    # HTTP PUT
+    def put(self):
+         return 'PUT is not supported', 405, {'Allow': 'POST'}
+
+    # HTTP DELETE
+    def delete(self):
+         return 'DELETE is not supported', 405, {'Allow': 'POST'}

--- a/api_emulator/redfish/ComputerSystem_api.py
+++ b/api_emulator/redfish/ComputerSystem_api.py
@@ -1,0 +1,218 @@
+# Copyright Notice:
+# Copyright 2017 Distributed Management Task Force, Inc. All rights reserved.
+# License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/Redfish-Interface-Emulator/LICENSE.md
+
+# Example Collection Resource and Singleton Resource
+"""
+Collection API  GET, POST
+Singleton  API  GET, POST, PATCH, DELETE
+
+"""
+import g
+
+import sys, traceback
+import logging
+import copy
+from flask import Flask, request, make_response, render_template
+from flask_restful import reqparse, Api, Resource
+
+from .templates.ComputerSystem import get_ComputerSystem_instance
+
+members = []
+member_ids = []
+foo = 'false'
+INTERNAL_ERROR = 500
+
+#ComputerSystem API
+class ComputerSystemAPI(Resource):
+    # kwargs is used to pass in the wildcards values to replace when the instance is created - via get_<resource>_instance().
+    #
+    # __init__ should store the wildcards and pass the wildcards to the get_<resource>_instance(). 
+    def __init__(self, **kwargs):
+        logging.basicConfig(level=logging.INFO)
+        logging.info('ComputerSystemAPI init called')
+        try:
+            global config
+            global wildcards
+            wildcards = kwargs
+        except Exception:
+            traceback.print_exc()
+
+    # HTTP GET
+    def get(self,ident):
+        try:
+            # Find the entry with the correct value for Id
+            resp = 404
+            for cfg in members:
+                if (ident == cfg["Id"]):
+                    config = cfg
+                    resp = config, 200
+                    break
+        except Exception:
+            traceback.print_exc()
+            resp = INTERNAL_ERROR
+        return resp
+
+    # HTTP POST
+    # - Create the resource (since URI variables are avaiable)
+    # - Update the members and members.id lists
+    # - Attach the APIs of subordinate resources (do this only once)
+    # - Finally, create an instance of the subordiante resources
+    def post(self,ident):
+        logging.info('ComputerSystemAPI PUT called')
+        try:
+            global config
+            global wildcards
+            wildcards['id'] = ident
+            config=get_ComputerSystem_instance(wildcards)
+            members.append(config)
+            member_ids.append({'@odata.id': config['@odata.id']})
+            global foo
+            # Attach URIs for subordiante resources
+            '''
+            if  (foo == 'false'):
+                # Add APIs for subordinate resourcs
+                collectionpath = g.rest_base + "ComputerSystems/" + ident + "/EgSubResources"
+                logging.info('collectionpath = ' + collectionpath)
+                g.api.add_resource(EgSubResourceCollectionAPI, collectionpath, resource_class_kwargs={'path': collectionpath} )
+                singletonpath = collectionpath + "/<string:ident>"
+                logging.info('singletonpath = ' + singletonpath)
+                g.api.add_resource(EgSubResourceAPI, singletonpath,  resource_class_kwargs={'rb': g.rest_base, 'eg_id': ident} )
+                foo = 'true'
+            '''
+            # Create an instance of subordinate resources
+            #cfg = CreateSubordinateRes()
+            #out = cfg.put(ident)
+            resp = config, 200
+        except Exception:
+            traceback.print_exc()
+            resp = INTERNAL_ERROR
+        logging.info('ComputerSystemAPI put exit')
+        return resp
+
+    # HTTP PATCH
+    def patch(self, ident):
+        logging.info('ComputerSystemAPI patch called')
+        raw_dict = request.get_json(force=True)
+        logging.info(raw_dict)
+        try:
+            # Find the entry with the correct value for Id
+            for cfg in members:
+                if (ident == cfg["Id"]):
+                    break
+            config = cfg
+            logging.info(config)
+            for key, value in raw_dict.items():
+                logging.info('Update ' + key + ' to ' + value)
+                config[key] = value
+            logging.info(config)
+            resp = config, 200
+        except Exception:
+            traceback.print_exc()
+            resp = INTERNAL_ERROR
+        return resp
+
+
+    # HTTP DELETE
+    def delete(self,ident):
+        # logging.info('ComputerSystemAPI delete called')
+        try:
+            idx = 0
+            for cfg in members:
+                if (ident == cfg["Id"]):
+                    break
+                idx += 1
+            members.pop(idx)
+            member_ids.pop(idx)
+            resp = 200
+        except Exception:
+            traceback.print_exc()
+            resp = INTERNAL_ERROR
+        return resp
+
+
+# ComputerSystem Collection API
+class ComputerSystemCollectionAPI(Resource):
+    def __init__(self):
+        self.rb = g.rest_base
+        self.config = {
+            '@odata.context': self.rb + '$metadata#ComputerSystemCollection.ComputerSystemCollection',
+            '@odata.id': self.rb + 'ComputerSystemCollection',
+            '@odata.type': '#ComputerSystemCollection.1.0.0.ComputerSystemCollection',
+            'Name': 'ComputerSystem Collection',
+            'Links': {}
+        }
+        self.config['Links']['Member@odata.count'] = len(member_ids)
+        self.config['Links']['Members'] = member_ids
+
+    def get(self):
+        try:
+            resp = self.config, 200
+        except Exception:
+            traceback.print_exc()
+            resp = INTERNAL_ERROR
+        return resp
+
+    # The POST command should be for adding multiple instances. For now, just add one.
+    # Todo - Fix so the config can be passed in the data.
+    def post(self):
+        try:
+            g.api.add_resource(ComputerSystemAPI, '/redfish/v1/ComputerSystems/<string:ident>')
+            resp=self.config,200
+        except Exception:
+            traceback.print_exc()
+            resp = INTERNAL_ERROR
+        return resp
+
+
+# CreateComputerSystem
+#
+# Called internally to create a instances of a resource.  If the resource has subordinate resources,
+# those subordinate resource(s)  should be created automatically.
+#
+# This routine can also be used to pre-populate emulator with resource instances.  For example, a couple of
+# Chassis and a ComputerSystem (see examples in resource_manager.py)
+#
+# Note: this may not the optimal way to pre-populate the emulator, since the resource_manager.py files needs
+# to be editted.  A better method is just hack up a copy of usertest.py which performs a POST for each resource
+# instance desired (e.g. populate.py).  Then one could have a multiple 'populate' files and the emulator doesn't
+# need to change.
+# 
+# Note: In 'init', the first time through, kwargs may not have any values, so we need to check.
+#   The call to 'init' stores the path wildcards. The wildcards are used when subsequent calls instanctiate
+#   resources to modify the resource template.
+#
+class CreateComputerSystem(Resource):
+    def __init__(self, **kwargs):
+        logging.info('CreateComputerSystem init called')
+        logging.debug(kwargs, kwargs.keys(), 'resource_class_kwargs' in kwargs)
+        if 'resource_class_kwargs' in kwargs:
+            global wildcards
+            wildcards = copy.deepcopy(kwargs['resource_class_kwargs'])
+            logging.debug(wildcards, wildcards.keys())
+
+    # Attach APIs for subordinate resource(s). Attach the APIs for a resource collection and its singletons
+    def put(self,ident):
+        logging.info('CreateComputerSystem put called')
+        try:
+            global config
+            global wildcards
+            wildcards['id'] = ident
+            config=get_ComputerSystem_instance(wildcards)
+            members.append(config)
+            member_ids.append({'@odata.id': config['@odata.id']})
+            '''
+            # attach subordinate resources
+            collectionpath = g.rest_base + "ComputerSystems/" + ident + "/EgSubResources"
+            logging.info('collectionpath = ' + collectionpath)
+            g.api.add_resource(EgSubResourceCollectionAPI, collectionpath, resource_class_kwargs={'path': collectionpath} )
+            singletonpath = collectionpath + "/<string:ident>"
+            logging.debug('singletonpath = ' + singletonpath)
+            g.api.add_resource(EgSubResourceAPI, singletonpath,  resource_class_kwargs={'rb': g.rest_base, 'eg_id': ident} )
+            '''
+            resp = config, 200
+        except Exception:
+            traceback.print_exc()
+            resp = INTERNAL_ERROR
+        logging.info('CreateComputerSystem init exit')
+        return resp

--- a/api_emulator/redfish/ComputerSystem_api.py
+++ b/api_emulator/redfish/ComputerSystem_api.py
@@ -17,6 +17,8 @@ from flask import Flask, request, make_response, render_template
 from flask_restful import reqparse, Api, Resource
 
 from .templates.ComputerSystem import get_ComputerSystem_instance
+from .ComputerSystem.ResetActionInfo_api import ResetActionInfo_API
+from .ComputerSystem.ResetAction_api import ResetAction_API
 
 members = []
 member_ids = []
@@ -201,6 +203,12 @@ class CreateComputerSystem(Resource):
             config=get_ComputerSystem_instance(wildcards)
             members.append(config)
             member_ids.append({'@odata.id': config['@odata.id']})
+
+            path = g.rest_base + "Systems/" + ident + "/ResetActionInfo"
+            g.api.add_resource(ResetActionInfo_API, path, resource_class_kwargs={'rb': g.rest_base, 'sys_id': ident})
+            path = g.rest_base + "Systems/" + ident + "/Actions/ComputerSystem.Reset"
+            g.api.add_resource(ResetAction_API, path, resource_class_kwargs={'rb': g.rest_base, 'sys_id': ident})
+
             '''
             # attach subordinate resources
             collectionpath = g.rest_base + "ComputerSystems/" + ident + "/EgSubResources"

--- a/api_emulator/redfish/EventService_api.py
+++ b/api_emulator/redfish/EventService_api.py
@@ -26,7 +26,7 @@ INTERNAL_ERROR = 500
 # EventService API
 class EventServiceAPI(Resource):
     def __init__(self, **kwargs):
-        print ('EventServiceAPI init called')
+        logging.info('EventServiceAPI init called')
         try:
             global config
             config=get_EventService_instance(kwargs)
@@ -37,7 +37,7 @@ class EventServiceAPI(Resource):
         except Exception:
             traceback.print_exc()
             resp = INTERNAL_ERROR
-        print ('CreateEventService put exit')
+        logging.info('CreateEventService put exit')
 
     # HTTP GET
     def get(self):
@@ -65,20 +65,20 @@ class EventServiceAPI(Resource):
 # Used to create a resource instance internally
 class CreateEventService(Resource):
     def __init__(self, **kwargs):
-        print ('CreateEventService init called')
-        logging.info(kwargs)
-        logging.info(kwargs.keys())
-        logging.info('resource_class_kwargs in kwargs')
+        logging.info('CreateEventService init called')
+        logging.debug(kwargs)
+        logging.debug(kwargs.keys())
         if 'resource_class_kwargs' in kwargs:
             global wildcards
             wildcards = copy.deepcopy(kwargs['resource_class_kwargs'])
             logging.debug(wildcards, wildcards.keys())
 
     def put(self,ident):
-        print ('CreateEventService put called')
+        logging.info('CreateEventService put called')
         try:
             global config
             global wildcards
+            wildcards['id'] = ident
             config=get_EventService_instance(wildcards)
             g.api.add_resource(SubscriptionCollectionAPI,   '/redfish/v1/EventService/Subscriptions')
             g.api.add_resource(SubscriptionAPI,             '/redfish/v1/EventService/Subscriptions/<string:ident>', resource_class_kwargs={'rb': g.rest_base})
@@ -90,5 +90,5 @@ class CreateEventService(Resource):
         except Exception:
             traceback.print_exc()
             resp = INTERNAL_ERROR
-        print ('CreateEventService put exit')
+        logging.info('CreateEventService put exit')
         return resp

--- a/api_emulator/redfish/Manager_api.py
+++ b/api_emulator/redfish/Manager_api.py
@@ -1,0 +1,224 @@
+# Copyright Notice:
+# Copyright 2017 Distributed Management Task Force, Inc. All rights reserved.
+# License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/Redfish-Interface-Emulator/LICENSE.md
+
+# Manager Collection Resource and Singleton Resource
+"""
+Collection API  GET, POST
+Singleton  API  GET, POST, PATCH, DELETE
+
+"""
+import g
+
+import sys, traceback
+import logging
+import copy
+from flask import Flask, request, make_response, render_template
+from flask_restful import reqparse, Api, Resource
+
+from .templates.Manager import get_Manager_instance
+
+#from .eg_subresource_api import EgSubResourceCollectionAPI, EgSubResourceAPI, CreateEgSubResource
+
+members = []
+member_ids = []
+foo = 'false'
+INTERNAL_ERROR = 500
+
+#Manager API
+class ManagerAPI(Resource):
+    # kwargs is used to pass in the wildcards values to replace when the instance is created - via get_<resource>_instance().
+    #
+    # __init__ should store the wildcards and pass the wildcards to the get_<resource>_instance(). 
+    def __init__(self, **kwargs):
+        logging.basicConfig(level=logging.INFO)
+        logging.info('ManagerAPI init called')
+        try:
+            global config
+            global wildcards
+            wildcards = kwargs
+#            config=get_Manager_instance(wildcards)
+#            resp = config, 200
+        except Exception:
+            traceback.print_exc()
+#            resp = INTERNAL_ERROR
+        logging.info('ManagerAPI init exit')
+
+    # HTTP GET
+    def get(self,ident):
+        try:
+            # Find the entry with the correct value for Id
+            resp = 404
+            for cfg in members:
+                if (ident == cfg["Id"]):
+                    config = cfg
+                    resp = config, 200
+                    break
+        except Exception:
+            traceback.print_exc()
+            resp = INTERNAL_ERROR
+        return resp
+
+    # HTTP POST
+    # - Create the resource (since URI variables are avaiable)
+    # - Update the members and members.id lists
+    # - Attach the APIs of subordinate resources (do this only once)
+    # - Finally, create an instance of the subordiante resources
+    def post(self,ident):
+        logging.info('ManagerAPI PUT called')
+        try:
+            global config
+            global wildcards
+            wildcards['id'] = ident
+            config=get_Manager_instance(wildcards)
+            members.append(config)
+            member_ids.append({'@odata.id': config['@odata.id']})
+            global foo
+            # Attach URIs for subordiante resources
+            '''
+            if  (foo == 'false'):
+                # Add APIs for subordinate resourcs
+                collectionpath = g.rest_base + "Managers/" + ident + "/EgSubResources"
+                logging.info('collectionpath = ' + collectionpath)
+                g.api.add_resource(EgSubResourceCollectionAPI, collectionpath, resource_class_kwargs={'path': collectionpath} )
+                singletonpath = collectionpath + "/<string:ident>"
+                logging.info('singletonpath = ' + singletonpath)
+                g.api.add_resource(EgSubResourceAPI, singletonpath,  resource_class_kwargs={'rb': g.rest_base, 'eg_id': ident} )
+                foo = 'true'
+            '''
+            # Create an instance of subordinate resources
+            #cfg = CreateSubordinateRes()
+            #out = cfg.put(ident)
+            resp = config, 200
+        except Exception:
+            traceback.print_exc()
+            resp = INTERNAL_ERROR
+        logging.info('ManagerAPI put exit')
+        return resp
+
+    # HTTP PATCH
+    def patch(self, ident):
+        logging.info('ManagerAPI patch called')
+        raw_dict = request.get_json(force=True)
+        logging.info(raw_dict)
+        try:
+            # Find the entry with the correct value for Id
+            for cfg in members:
+                if (ident == cfg["Id"]):
+                    break
+            config = cfg
+            logging.info(config)
+            for key, value in raw_dict.items():
+                logging.info('Update ' + key + ' to ' + value)
+                config[key] = value
+            logging.info(config)
+            resp = config, 200
+        except Exception:
+            traceback.print_exc()
+            resp = INTERNAL_ERROR
+        return resp
+
+
+    # HTTP DELETE
+    def delete(self,ident):
+        # logging.info('ManagerAPI delete called')
+        try:
+            idx = 0
+            for cfg in members:
+                if (ident == cfg["Id"]):
+                    break
+                idx += 1
+            members.pop(idx)
+            member_ids.pop(idx)
+            resp = 200
+        except Exception:
+            traceback.print_exc()
+            resp = INTERNAL_ERROR
+        return resp
+
+
+# Manager Collection API
+class ManagerCollectionAPI(Resource):
+    def __init__(self):
+        self.rb = g.rest_base
+        self.config = {
+            '@odata.context': self.rb + '$metadata#ManagerCollection.ManagerCollection',
+            '@odata.id': self.rb + 'ManagerCollection',
+            '@odata.type': '#ManagerCollection.1.0.0.ManagerCollection',
+            'Name': 'Manager Collection',
+            'Links': {}
+        }
+        self.config['Links']['Member@odata.count'] = len(member_ids)
+        self.config['Links']['Members'] = member_ids
+
+    def get(self):
+        try:
+            resp = self.config, 200
+        except Exception:
+            traceback.print_exc()
+            resp = INTERNAL_ERROR
+        return resp
+
+    # The POST command should be for adding multiple instances. For now, just add one.
+    # Todo - Fix so the config can be passed in the data.
+    def post(self):
+        try:
+            g.api.add_resource(ManagerAPI, '/redfish/v1/Managers/<string:ident>')
+            resp=self.config,200
+        except Exception:
+            traceback.print_exc()
+            resp = INTERNAL_ERROR
+        return resp
+
+
+# CreateManager
+#
+# Called internally to create a instances of a resource.  If the resource has subordinate resources,
+# those subordinate resource(s)  should be created automatically.
+#
+# This routine can also be used to pre-populate emulator with resource instances.  For example, a couple of
+# Chassis and a Manager (see examples in resource_manager.py)
+#
+# Note: this may not the optimal way to pre-populate the emulator, since the resource_manager.py files needs
+# to be editted.  A better method is just hack up a copy of usertest.py which performs a POST for each resource
+# instance desired (e.g. populate.py).  Then one could have a multiple 'populate' files and the emulator doesn't
+# need to change.
+# 
+# Note: In 'init', the first time through, kwargs may not have any values, so we need to check.
+#   The call to 'init' stores the path wildcards. The wildcards are used when subsequent calls instanctiate
+#   resources to modify the resource template.
+#
+class CreateManager(Resource):
+    def __init__(self, **kwargs):
+        logging.info('CreateManager init called')
+        logging.debug(kwargs, kwargs.keys(), 'resource_class_kwargs' in kwargs)
+        if 'resource_class_kwargs' in kwargs:
+            global wildcards
+            wildcards = copy.deepcopy(kwargs['resource_class_kwargs'])
+            logging.debug(wildcards, wildcards.keys())
+
+    # Attach APIs for subordinate resource(s). Attach the APIs for a resource collection and its singletons
+    def put(self,ident):
+        logging.info('CreateManager put called')
+        try:
+            global config
+            global wildcards
+            wildcards['id'] = ident
+            config=get_Manager_instance(wildcards)
+            members.append(config)
+            member_ids.append({'@odata.id': config['@odata.id']})
+            '''
+            # attach subordinate resources
+            collectionpath = g.rest_base + "Managers/" + ident + "/EgSubResources"
+            logging.info('collectionpath = ' + collectionpath)
+            g.api.add_resource(EgSubResourceCollectionAPI, collectionpath, resource_class_kwargs={'path': collectionpath} )
+            singletonpath = collectionpath + "/<string:ident>"
+            logging.debug('singletonpath = ' + singletonpath)
+            g.api.add_resource(EgSubResourceAPI, singletonpath,  resource_class_kwargs={'rb': g.rest_base, 'eg_id': ident} )
+            '''
+            resp = config, 200
+        except Exception:
+            traceback.print_exc()
+            resp = INTERNAL_ERROR
+        logging.info('CreateManager init exit')
+        return resp

--- a/api_emulator/redfish/chassis_api.py
+++ b/api_emulator/redfish/chassis_api.py
@@ -1,17 +1,22 @@
 # Copyright Notice:
-# Copyright 2016 Distributed Management Task Force, Inc. All rights reserved.
+# Copyright 2017 Distributed Management Task Force, Inc. All rights reserved.
 # License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/Redfish-Interface-Emulator/LICENSE.md
 
-# Collection API  GET, POST
-# Singleton  API  GET, PUT, PATCH, DELETE
+# Chassis Collection Resource and Singleton Resource
+"""
+Collection API  GET, POST
+Singleton  API  GET, POST, PATCH, DELETE
 
+"""
 import g
 
 import sys, traceback
+import logging
+import copy
 from flask import Flask, request, make_response, render_template
 from flask_restful import reqparse, Api, Resource
 
-from .templates.chassis import get_Chassis_template
+from .templates.Chassis import get_Chassis_instance
 from .thermal_api import ThermalAPI, CreateThermal
 from .power_api import PowerAPI, CreatePower
 
@@ -23,38 +28,54 @@ INTERNAL_ERROR = 500
 
 #Chassis API
 class ChassisAPI(Resource):
-    # Can't initialize the resource since the URI variables are not in the argument list.
-    # Need the variables to set the Odata.id properties
-    def __init__(self):
-        print ('ChassisAPI init called')
+    # kwargs is used to pass in the wildcards values to replace when the instance is created - via get_<resource>_instance().
+    #
+    # __init__ should store the wildcards and pass the wildcards to the get_<resource>_instance(). 
+    def __init__(self, **kwargs):
+        logging.basicConfig(level=logging.INFO)
+        logging.info('ChassisAPI init called')
+        try:
+            global config
+            global wildcards
+            wildcards = kwargs
+#            config=get_Chassis_instance(wildcards)
+#            resp = config, 200
+        except Exception:
+            traceback.print_exc()
+#            resp = INTERNAL_ERROR
+        logging.info('ChassisAPI init exit')
 
     # HTTP GET
     def get(self,ident):
         try:
             # Find the entry with the correct value for Id
+            resp = 404
             for cfg in members:
                 if (ident == cfg["Id"]):
+                    config = cfg
+                    resp = config, 200
                     break
-            config = cfg
-            resp = config, 200
         except Exception:
             traceback.print_exc()
             resp = INTERNAL_ERROR
         return resp
 
-    # HTTP PUT
+    # HTTP POST
     # - Create the resource (since URI variables are avaiable)
     # - Update the members and members.id lists
     # - Attach the APIs of subordinate resources (do this only once)
     # - Finally, create an instance of the subordiante resources
-    def put(self,ident):
-        print ('ChassisAPI put called')
+    def post(self,ident):
+        logging.info('ChassisAPI PUT called')
         try:
             global config
-            config=get_Chassis_template(g.rest_base,ident)
+            global wildcards
+            wildcards['id'] = ident
+            config=get_Chassis_instance(wildcards)
             members.append(config)
             member_ids.append({'@odata.id': config['@odata.id']})
             global foo
+            '''
             # Attach URIs for subordiante resources
             if  (foo == 'false'):
                 g.api.add_resource(ThermalAPI, '/redfish/v1/Chassis/<string:ch_id>/Thermal')
@@ -65,29 +86,47 @@ class ChassisAPI(Resource):
             out = cfg.put(ident)
             cfg = CreatePower()
             out = cfg.put(ident)
+            # Attach URIs for subordiante resources
+            '''
+            if  (foo == 'false'):
+                # Power subordinate resource
+                path = g.rest_base + "Chassiss/" + ident + "/Power"
+                logging.info('power path = ' + path)
+                g.api.add_resource(PowerAPI,   path, resource_class_kwargs={'rb': g.rest_base, 'ch_id': ident} )
+                config = CreatePower()
+                out = config.__init__(resource_class_kwargs={'rb': g.rest_base,'ch_id': ident})
+                out = config.put("Power")
+                # Thermal subordinate resource
+                path = g.rest_base + "Chassiss/" + ident + "/Thermal"
+                logging.info('thermal path = ' + path)
+                g.api.add_resource(ThermalAPI, path, resource_class_kwargs={'rb': g.rest_base, 'ch_id': ident} )
+                config = CreateThermal()
+                out = config.__init__(resource_class_kwargs={'rb': g.rest_base,'ch_id': ident})
+                out = config.put("Thermal")
+                foo = 'true'
             resp = config, 200
         except Exception:
             traceback.print_exc()
             resp = INTERNAL_ERROR
-        print ('ChassisAPI put exit')
+        logging.info('ChassisAPI put exit')
         return resp
 
     # HTTP PATCH
     def patch(self, ident):
-        print ('ChassisAPI patch called')
+        logging.info('ChassisAPI patch called')
         raw_dict = request.get_json(force=True)
-        print (raw_dict)
+        logging.info(raw_dict)
         try:
             # Find the entry with the correct value for Id
             for cfg in members:
                 if (ident == cfg["Id"]):
                     break
             config = cfg
-            print (config)
+            logging.info(config)
             for key, value in raw_dict.items():
-                print ('Update ' + key + ' to ' + value)
+                logging.info('Update ' + key + ' to ' + value)
                 config[key] = value
-            print (config)
+            logging.info(config)
             resp = config, 200
         except Exception:
             traceback.print_exc()
@@ -97,7 +136,7 @@ class ChassisAPI(Resource):
 
     # HTTP DELETE
     def delete(self,ident):
-        # print ('ChassisAPI delete called')
+        # logging.info('ChassisAPI delete called')
         try:
             idx = 0
             for cfg in members:
@@ -113,12 +152,12 @@ class ChassisAPI(Resource):
         return resp
 
 
-# Chassis Collection API (Chassis has the same form for singular and plural)
+# Chassis Collection API
 class ChassisCollectionAPI(Resource):
     def __init__(self):
         self.rb = g.rest_base
         self.config = {
-            '@odata.context': self.rb + '$metadata#ChassisCollection',
+            '@odata.context': self.rb + '$metadata#ChassisCollection.ChassisCollection',
             '@odata.id': self.rb + 'ChassisCollection',
             '@odata.type': '#ChassisCollection.1.0.0.ChassisCollection',
             'Name': 'Chassis Collection',
@@ -139,7 +178,7 @@ class ChassisCollectionAPI(Resource):
     # Todo - Fix so the config can be passed in the data.
     def post(self):
         try:
-            g.api.add_resource(ChassisAPI, '/redfish/v1/Chassis/<string:ident>')
+            g.api.add_resource(ChassisAPI, '/redfish/v1/Chassiss/<string:ident>')
             resp=self.config,200
         except Exception:
             traceback.print_exc()
@@ -147,23 +186,60 @@ class ChassisCollectionAPI(Resource):
         return resp
 
 
-# Used to create a resource instance internally
-class CreateChassis(object):
-    def __init__(self):
-        print ('CreateChassis init called')
+# CreateChassis
+#
+# Called internally to create a instances of a resource.  If the resource has subordinate resources,
+# those subordinate resource(s)  should be created automatically.
+#
+# This routine can also be used to pre-populate emulator with resource instances.  For example, a couple of
+# Chassis and a Chassis (see examples in resource_manager.py)
+#
+# Note: this may not the optimal way to pre-populate the emulator, since the resource_manager.py files needs
+# to be editted.  A better method is just hack up a copy of usertest.py which performs a POST for each resource
+# instance desired (e.g. populate.py).  Then one could have a multiple 'populate' files and the emulator doesn't
+# need to change.
+# 
+# Note: In 'init', the first time through, kwargs may not have any values, so we need to check.
+#   The call to 'init' stores the path wildcards. The wildcards are used when subsequent calls instanctiate
+#   resources to modify the resource template.
+#
+class CreateChassis(Resource):
+    def __init__(self, **kwargs):
+        logging.info('CreateChassis init called')
+        logging.debug(kwargs, kwargs.keys(), 'resource_class_kwargs' in kwargs)
+        if 'resource_class_kwargs' in kwargs:
+            global wildcards
+            wildcards = copy.deepcopy(kwargs['resource_class_kwargs'])
+            logging.debug(wildcards, wildcards.keys())
 
+    # Attach APIs for subordinate resource(s). Attach the APIs for a resource collection and its singletons
     def put(self,ident):
-        print ('CreateChassis put called')
+        logging.info('CreateChassis put called')
         try:
             global config
-            config=get_Chassis_template(g.rest_base,ident)
+            global wildcards
+            wildcards['id'] = ident
+            config=get_Chassis_instance(wildcards)
             members.append(config)
             member_ids.append({'@odata.id': config['@odata.id']})
-            g.api.add_resource(ThermalAPI, '/redfish/v1/Chassis/<string:ch_id>/Thermal')
-            g.api.add_resource(PowerAPI, '/redfish/v1/Chassis/<string:ch_id>/Power')
+            # Power subordinate resource
+            path = g.rest_base + "Chassis/" + ident + "/Power"
+            logging.info('power path = ' + path)
+            g.api.add_resource(PowerAPI,   path, resource_class_kwargs={'rb': g.rest_base, 'ch_id': ident} )
+            config = CreatePower()
+            out = config.__init__(resource_class_kwargs={'rb': g.rest_base,'ch_id': ident})
+            out = config.put("Power")
+            # Thermal subordinate resource
+            path = g.rest_base + "Chassis/" + ident + "/Thermal"
+            logging.info('thermal path = ' + path)
+            g.api.add_resource(ThermalAPI, path, resource_class_kwargs={'rb': g.rest_base, 'ch_id': ident} )
+            config = CreateThermal()
+            out = config.__init__(resource_class_kwargs={'rb': g.rest_base,'ch_id': ident})
+            out = config.put("Thermal")
+
             resp = config, 200
         except Exception:
             traceback.print_exc()
             resp = INTERNAL_ERROR
-        print ('CreateChassis put exit')
+        logging.info('CreateChassis init exit')
         return resp

--- a/api_emulator/redfish/eg_resource_api.py
+++ b/api_emulator/redfish/eg_resource_api.py
@@ -199,6 +199,7 @@ class CreateEgResource(Resource):
         try:
             global config
             global wildcards
+            wildcards['id'] = ident
             config=get_EgResource_instance2(wildcards)
             members.append(config)
             member_ids.append({'@odata.id': config['@odata.id']})

--- a/api_emulator/redfish/power_api.py
+++ b/api_emulator/redfish/power_api.py
@@ -5,12 +5,13 @@
 # Singleton API: GET, PATCH
 
 import g
-
+import copy
+import logging
 import sys, traceback
 from flask import Flask, request, make_response, render_template
 from flask_restful import reqparse, Api, Resource
 
-from .templates.power import get_power_template
+from .templates.power import get_power_instance
 
 # config is instantiated by CreatePower()
 config = {}
@@ -20,11 +21,18 @@ INTERNAL_ERROR = 500
 class PowerAPI(Resource):
     # Can't initialize the resource since the URI variables are not in the argument list.
     # Need the variables to set the Odata.id properties
-    def __init__(self):
-        print ('PowerAPI init called')
+    def __init__(self, **kwargs):
+        logging.info('PowerAPI init called')
+        try:
+            global config
+            config=get_Power_instance(kwargs)
+            resp = config, 200
+        except Exception:
+            traceback.print_exc()
+            resp = INTERNAL_ERROR
 
     # HTTP GET
-    def get(self,ch_id):
+    def get(self):
         try:
             global config
             resp = config, 200
@@ -34,17 +42,16 @@ class PowerAPI(Resource):
         return resp
 
     # HTTP PATCH
-    def patch(self, ch_id):
-        print ('PowerAPI patch called')
+    def patch(self):
+        logging.info('PowerAPI patch called')
         raw_dict = request.get_json(force=True)
-        print (raw_dict)
         try:
             global config
-            print (config)
+            logging.debug(config)
             for key, value in raw_dict.items():
                 print ('Update ' + key + ' to ' + value)
                 config[key] = value
-            print (config)
+            logging.debug(config)
             resp = config, 200
         except Exception:
             traceback.print_exc()
@@ -52,7 +59,7 @@ class PowerAPI(Resource):
         return resp
 
     # HTTP PUT
-    def put(self,ch_id):
+    def put(self):
          return 'PUT is not a valid command', 202
 
     # HTTP DELETE
@@ -60,20 +67,25 @@ class PowerAPI(Resource):
          return 'DELETE is not a valid command', 202
 
 # Used to create a resource instance internally
-class CreatePower(object):
-    def __init__(self):
-        print ('CreatePower init called')
+class CreatePower(Resource):
+    def __init__(self, **kwargs):
+        logging.info('CreatePower init called')
+        if 'resource_class_kwargs' in kwargs:
+            global wildcards
+            wildcards = copy.deepcopy(kwargs['resource_class_kwargs'])
+            logging.info(wildcards)
+            logging.info(wildcards.keys())
 
     # PUT
     # - Create the resource (since URI variables are avaiable)
     def put(self,ch_id):
-        print ('CreatePower put called')
+        logging.info('CreatePower put called')
         try:
             global config
-            config=get_power_template(g.rest_base,ch_id)
+            global wildcards
+            config=get_power_instance(wildcards)
             resp = config, 200
         except Exception:
             traceback.print_exc()
             resp = INTERNAL_ERROR
-        print ('CreatePower put exit')
         return resp

--- a/api_emulator/redfish/templates/ComputerSystem.py
+++ b/api_emulator/redfish/templates/ComputerSystem.py
@@ -1,0 +1,153 @@
+# Copyright Notice:
+# Copyright 2017 Distributed Management Task Force, Inc. All rights reserved.
+# License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/Redfish-Interface-Emulator/LICENSE.md
+
+# Example Resoruce Template
+import copy
+import strgen
+
+_TEMPLATE = \
+{
+    "@Redfish.Copyright": "Copyright 2014-2016 Distributed Management Task Force, Inc. (DMTF). All rights reserved.",
+    "@odata.context": "{rb}$metadata#ComputerSystem.ComputerSystem",
+    "@odata.id": "{rb}Systems/{id}",
+    "@odata.type": "#ComputerSystem.v1_3_0.ComputerSystem",
+    "Id": "{id}",
+    "Name": "My Computer System",
+    "SystemType": "Physical",
+    "AssetTag": "free form asset tag",
+    "Manufacturer": "Manufacturer Name",
+    "Model": "Model Name",
+    "SKU": "",
+    "SerialNumber": "2M220100SL",
+    "PartNumber": "",
+    "Description": "Description of server",
+    "UUID": "00000000-0000-0000-0000-000000000000",
+    "HostName": "web-srv344",
+    "Status": {
+        "State": "Enabled",
+        "Health": "OK",
+        "HealthRollup": "OK"
+    },
+    "IndicatorLED": "Off",
+    "PowerState": "On",
+    "Boot": {
+        "BootSourceOverrideEnabled": "Once",
+        "BootSourceOverrideMode": "UEFI",
+        "BootSourceOverrideTarget": "Pxe",
+        "BootSourceOverrideTarget@Redfish.AllowableValues": [
+            "None",
+            "Pxe",
+            "Floppy",
+            "Cd",
+            "Usb",
+            "Hdd",
+            "BiosSetup",
+            "Utilities",
+            "Diags",
+            "UefiTarget",
+            "SDCard",
+            "UefiHttp"
+        ],
+        "UefiTargetBootSourceOverride": "uefi device path"
+    },
+    "BiosVersion": "P79 v1.00 (09/20/2013)",
+    "ProcessorSummary": {
+        "Count": 8,
+        "Model": "Multi-Core Intel(R) Xeon(R) processor 7xxx Series",
+        "Status": {
+            "State": "Enabled",
+            "Health": "OK",
+            "HealthRollup": "OK"
+        }
+    },
+    "MemorySummary": {
+        "TotalSystemMemoryGiB": 16,
+        "MemoryMirroring" : "System",
+        "Status": {
+            "State": "Enabled",
+            "Health": "OK",
+            "HealthRollup": "OK"
+        }
+    },
+    "TrustedModules": [
+        {
+          "Status": {
+            "State": "Enabled",
+            "Health": "OK"
+           },
+           "ModuleType":"TPM2_0",
+           "FirmwareVersion": "3.1",
+           "FirmwareVersion2": "1",
+           "InterfaceTypeSelection": "None"
+        }
+    ],
+    "Processors": {
+        "@odata.id": "{rb}Systems/{id}/Processors"
+    },
+    "Memory": {
+        "@odata.id": "{rb}Systems/{id}/Memory"
+    },
+    "EthernetInterfaces": {
+        "@odata.id": "{rb}Systems/{id}/EthernetInterfaces"
+    },
+    "NetworkInterfaces": {
+        "@odata.id": "{rb}Systems/{id}/NetworkInterfaces"
+    },
+    "SimpleStorage": {
+        "@odata.id": "{rb}Systems/{id}/SimpleStorage"
+    },
+    "Links": {
+        "Chassis": [
+            {
+                "@odata.id": "{rb}Chassis/1"
+            }
+        ],
+        "ManagedBy": [
+            {
+                "@odata.id": "{rb}Managers/1"
+            }
+        ],
+        "Endpoints": [
+            {
+                "@odata.id": "{rb}Fabrics/PCIe/Endpoints/HostRootComplex1"
+            }
+        ],
+        "Oem": {}
+    },
+    "Actions": {
+        "#ComputerSystem.Reset": {
+            "target": "{rb}Systems/{id}/Actions/ComputerSystem.Reset", "@Redfish.ActionInfo": "{rb}Systems/{id}/ResetActionInfo"
+        },
+    }
+}
+
+
+def get_ComputerSystem_instance(wildcards):
+    """
+    Instantiate and format the template
+
+    Arguments:
+        wildcard - A dictionary of wildcards strings and their repalcement values
+
+    """
+    c = copy.deepcopy(_TEMPLATE)
+
+    c['@odata.context'] = c['@odata.context'].format(**wildcards)
+    c['@odata.id'] = c['@odata.id'].format(**wildcards)
+    c['Id'] = c['Id'].format(**wildcards)
+
+    c['Processors']['@odata.id'] = c['Processors']['@odata.id'].format(**wildcards)
+    c['Memory']['@odata.id'] = c['Memory']['@odata.id'].format(**wildcards)
+    c['EthernetInterfaces']['@odata.id'] = c['EthernetInterfaces']['@odata.id'].format(**wildcards)
+    c['NetworkInterfaces']['@odata.id'] = c['NetworkInterfaces']['@odata.id'].format(**wildcards)
+    c['SimpleStorage']['@odata.id'] = c['SimpleStorage']['@odata.id'].format(**wildcards)
+
+    c['Links']['Chassis'][0]['@odata.id'] = c['Links']['Chassis'][0]['@odata.id'].format(**wildcards)
+    c['Links']['ManagedBy'][0]['@odata.id'] = c['Links']['ManagedBy'][0]['@odata.id'].format(**wildcards)
+    c['Links']['Endpoints'][0]['@odata.id'] = c['Links']['Endpoints'][0]['@odata.id'].format(**wildcards)
+
+    c['Actions']['#ComputerSystem.Reset']['target'] = c['Actions']['#ComputerSystem.Reset']['target'].format(**wildcards)
+    c['Actions']['#ComputerSystem.Reset']['@Redfish.ActionInfo'] = c['Actions']['#ComputerSystem.Reset']['@Redfish.ActionInfo'].format(**wildcards)
+
+    return c

--- a/api_emulator/redfish/templates/ComputerSystem.py
+++ b/api_emulator/redfish/templates/ComputerSystem.py
@@ -100,12 +100,12 @@ _TEMPLATE = \
     "Links": {
         "Chassis": [
             {
-                "@odata.id": "{rb}Chassis/1"
+                "@odata.id": "{rb}Chassis/{linkChassis}"
             }
         ],
         "ManagedBy": [
             {
-                "@odata.id": "{rb}Managers/1"
+                "@odata.id": "{rb}Managers/{linkMgr}"
             }
         ],
         "Endpoints": [

--- a/api_emulator/redfish/templates/Manager.py
+++ b/api_emulator/redfish/templates/Manager.py
@@ -68,18 +68,17 @@ _TEMPLATE = \
     "Links": {
         "ManagerForServers": [
             {
-                "@odata.id": "{rb}Systems/1"
+                "@odata.id": "{rb}Systems/{linkSystem}"
             }
         ],
         "ManagerForChassis": [
             {
-                "@odata.id": "{rb}Chassis/1"
+                "@odata.id": "{rb}Chassis/{linkChassis}"
             }
         ],
         "ManagerInChassis": {
-            "@odata.id": "{rb}Chassis/1"
-        },
-        "Oem": {}
+            "@odata.id": "{rb}Chassis/{linkInChassis}"
+        }
     },
     "Actions": {
         "#Manager.Reset": {

--- a/api_emulator/redfish/templates/Manager.py
+++ b/api_emulator/redfish/templates/Manager.py
@@ -1,0 +1,122 @@
+# Copyright Notice:
+# Copyright 2017 Distributed Management Task Force, Inc. All rights reserved.
+# License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/Redfish-Interface-Emulator/LICENSE.md
+
+# Example Resoruce Template
+import copy
+import strgen
+
+_TEMPLATE = \
+{
+    "@Redfish.Copyright": "Copyright 2014-2016 Distributed Management Task Force, Inc. (DMTF). All rights reserved.",
+    "@odata.context": "{rb}$metadata#Manager.Manager",
+    "@odata.id": "{rb}Managers/{id}",
+    "@odata.type": "#Manager.v1_1_0.Manager",
+    "Id": "{id}",
+    "Name": "Manager",
+    "ManagerType": "BMC",
+    "Description": "BMC",
+    "ServiceEntryPointUUID": "92384634-2938-2342-8820-489239905423",
+    "UUID": "00000000-0000-0000-0000-000000000000",
+    "Model": "Joo Janta 200",
+    "DateTime": "2015-03-13T04:14:33+06:00",
+    "DateTimeLocalOffset": "+06:00",
+    "Status": {
+        "State": "Enabled",
+        "Health": "OK"
+    },
+    "GraphicalConsole": {
+        "ServiceEnabled": "true",
+        "MaxConcurrentSessions": 2,
+        "ConnectTypesSupported": [
+            "KVMIP"
+        ]
+    },
+    "SerialConsole": {
+        "ServiceEnabled": "true",
+        "MaxConcurrentSessions": 1,
+        "ConnectTypesSupported": [
+            "Telnet",
+            "SSH",
+            "IPMI"
+        ]
+    },
+    "CommandShell": {
+        "ServiceEnabled": "true",
+        "MaxConcurrentSessions": 4,
+        "ConnectTypesSupported": [
+            "Telnet",
+            "SSH"
+        ]
+    },
+    "FirmwareVersion": "1.00",
+    "NetworkProtocol": {
+        "@odata.id": "{rb}Managers/{id}/NetworkProtocol"
+    },
+    "EthernetInterfaces": {
+        "@odata.id": "{rb}Managers/{id}/EthernetInterfaces"
+    },
+    "SerialInterfaces": {
+        "@odata.id": "{rb}Managers/{id}/SerialInterfaces"
+    },
+    "LogServices": {
+        "@odata.id": "{rb}Managers/{id}/LogServices"
+    },
+    "VirtualMedia": {
+        "@odata.id": "{rb}Managers/{id}/VM1"
+    },
+    "Links": {
+        "ManagerForServers": [
+            {
+                "@odata.id": "{rb}Systems/1"
+            }
+        ],
+        "ManagerForChassis": [
+            {
+                "@odata.id": "{rb}Chassis/1"
+            }
+        ],
+        "ManagerInChassis": {
+            "@odata.id": "{rb}Chassis/1"
+        },
+        "Oem": {}
+    },
+    "Actions": {
+        "#Manager.Reset": {
+            "target": "{rb}Managers/{id}/Actions/Manager.Reset",
+            "ResetType@Redfish.AllowableValues": [
+                "ForceRestart",
+                "GracefulRestart"
+            ]
+        }
+    }
+}
+
+def get_Manager_instance(wildcards):
+    """
+    Instantiate and format the template
+
+    Arguments:
+        wildcard - A dictionary of wildcards strings and their repalcement values
+
+    """
+    c = copy.deepcopy(_TEMPLATE)
+
+    c['@odata.context'] = c['@odata.context'].format(**wildcards)
+    c['@odata.id'] = c['@odata.id'].format(**wildcards)
+    c['Id'] = c['Id'].format(**wildcards)
+
+    c['NetworkProtocol']['@odata.id'] = c['NetworkProtocol']['@odata.id'].format(**wildcards)
+    c['EthernetInterfaces']['@odata.id'] = c['EthernetInterfaces']['@odata.id'].format(**wildcards)
+    c['SerialInterfaces']['@odata.id'] = c['SerialInterfaces']['@odata.id'].format(**wildcards)
+    c['LogServices']['@odata.id'] = c['LogServices']['@odata.id'].format(**wildcards)
+    c['VirtualMedia']['@odata.id'] = c['VirtualMedia']['@odata.id'].format(**wildcards)
+
+    c['Links']['ManagerForServers'][0]['@odata.id'] = c['Links']['ManagerForServers'][0]['@odata.id'].format(**wildcards)
+    c['Links']['ManagerForChassis'][0]['@odata.id'] = c['Links']['ManagerForChassis'][0]['@odata.id'].format(**wildcards)
+
+    c['Links']['ManagerInChassis']['@odata.id'] = c['Links']['ManagerInChassis']['@odata.id'].format(**wildcards)
+
+    c['Actions']['#Manager.Reset']['target'] = c['Actions']['#Manager.Reset']['target'].format(**wildcards)
+
+    return c

--- a/api_emulator/redfish/templates/chassis.py
+++ b/api_emulator/redfish/templates/chassis.py
@@ -7,7 +7,7 @@
 import copy
 import strgen
 
-_CHASSIS_TEMPLATE = \
+_TEMPLATE = \
     {
         "@odata.context": "{rb}$metadata#Chassis/Links/Members/$entity",
         "@odata.id": "{rb}Chassis/{id}",
@@ -47,7 +47,7 @@ _CHASSIS_TEMPLATE = \
     }
 
 
-def get_Chassis_template(rest_base, ident):
+def get_Chassis_instance(wildcards):
     """
     Formats the template
 
@@ -55,15 +55,15 @@ def get_Chassis_template(rest_base, ident):
         rest_base - Base URL for the RESTful interface
         indent    - ID of the chassis
     """
-    c = copy.deepcopy(_CHASSIS_TEMPLATE)
+    c = copy.deepcopy(_TEMPLATE)
 
-    c['@odata.context'] = c['@odata.context'].format(rb=rest_base)
-    c['@odata.id'] = c['@odata.id'].format(rb=rest_base, id=ident)
-    c['Id'] = c['Id'].format(id=ident)
-    c['Thermal']['@odata.id'] = c['Thermal']['@odata.id'].format(rb=rest_base, id=ident)
-    c['Power']['@odata.id'] = c['Power']['@odata.id'].format(rb=rest_base, id=ident)
-    c['Links']['ManagedBy'][0]['@odata.id'] = c['Links']['ManagedBy'][0]['@odata.id'].format(rb=rest_base, id=ident)
-    c['Links']['ComputerSystems'][0]['@odata.id']=c['Links']['ComputerSystems'][0]['@odata.id'].format(rb=rest_base)
+    c['@odata.context'] = c['@odata.context'].format(**wildcards)
+    c['@odata.id'] = c['@odata.id'].format(**wildcards)
+    c['Id'] = c['Id'].format(**wildcards)
+    c['Thermal']['@odata.id'] = c['Thermal']['@odata.id'].format(**wildcards)
+    c['Power']['@odata.id'] = c['Power']['@odata.id'].format(**wildcards)
+    c['Links']['ManagedBy'][0]['@odata.id'] = c['Links']['ManagedBy'][0]['@odata.id'].format(**wildcards)
+    c['Links']['ComputerSystems'][0]['@odata.id']=c['Links']['ComputerSystems'][0]['@odata.id'].format(**wildcards)
 
     c['SerialNumber'] = strgen.StringGenerator('[A-Z]{3}[0-9]{10}').render()
 

--- a/api_emulator/redfish/templates/chassis.py
+++ b/api_emulator/redfish/templates/chassis.py
@@ -9,7 +9,7 @@ import strgen
 
 _TEMPLATE = \
     {
-        "@odata.context": "{rb}$metadata#Chassis/Links/Members/$entity",
+        "@odata.context": "{rb}$metadata#Chassis.Chassis",
         "@odata.id": "{rb}Chassis/{id}",
         "@odata.type": "#Chassis.v1_0_0.Chassis",
         "Id": "{id}",
@@ -35,12 +35,12 @@ _TEMPLATE = \
         "Links": {
             "ComputerSystems": [
                 {
-                    "@odata.id": "{rb}Systems/"
+                    "@odata.id": "{rb}Systems/{linkSystem}"
                 }
             ],
             "ManagedBy": [
                 {
-                    "@odata.id": "{rb}Managers/1"
+                    "@odata.id": "{rb}Managers/{linkMgr}"
                 }
             ],
          },

--- a/api_emulator/redfish/templates/power.py
+++ b/api_emulator/redfish/templates/power.py
@@ -6,7 +6,7 @@
 
 import copy
 
-_POWER_TEMPLATE = \
+_TEMPLATE = \
     {
     "@odata.context": "{rb}$metadata#Chassis/Links/Members/{ch_id}/Links/Power/$entity",
     "@odata.id": "{rb}Chassis/{ch_id}/Power",
@@ -150,7 +150,7 @@ _POWER_TEMPLATE = \
 }
 
 
-def get_power_template(rest_base, ident):
+def get_power_instance(wildcards):
     """
     Returns a formatted template
 
@@ -158,24 +158,23 @@ def get_power_template(rest_base, ident):
         rest_base - Base URL of the RESTful interface
         ident     - Identifier of the chassis
     """
-    c = copy.deepcopy(_POWER_TEMPLATE)
+    c = copy.deepcopy(_TEMPLATE)
 
-    #c['Modified'] = timestamp()
-    c['@odata.context'] = c['@odata.context'].format(rb=rest_base, ch_id=ident)
-    c['@odata.id'] = c['@odata.id'].format(rb=rest_base, ch_id=ident)
-    c['PowerControl'][0]['@odata.id']=c['PowerControl'][0]['@odata.id'].format(rb=rest_base,ch_id=ident)
-    c['PowerControl'][0]['RelatedItem'][0]['@odata.id']=c['PowerControl'][0]['RelatedItem'][0]['@odata.id'].format(rb=rest_base,ch_id=ident)
-    c['PowerControl'][0]['RelatedItem'][1]['@odata.id']=c['PowerControl'][0]['RelatedItem'][1]['@odata.id'].format(rb=rest_base,ch_id=ident)
-    c['Voltages'][0]['@odata.id']=c['Voltages'][0]['@odata.id'].format(rb=rest_base,ch_id=ident)
-    c['Voltages'][0]['RelatedItem'][0]['@odata.id']=c['Voltages'][0]['RelatedItem'][0]['@odata.id'].format(rb=rest_base,ch_id=ident)
-    c['Voltages'][0]['RelatedItem'][1]['@odata.id']=c['Voltages'][0]['RelatedItem'][1]['@odata.id'].format(rb=rest_base,ch_id=ident)
-    c['Voltages'][1]['@odata.id']=c['Voltages'][1]['@odata.id'].format(rb=rest_base,ch_id=ident)
-    c['Voltages'][1]['RelatedItem'][0]['@odata.id']=c['Voltages'][1]['RelatedItem'][0]['@odata.id'].format(rb=rest_base,ch_id=ident)
-    c['Voltages'][1]['RelatedItem'][1]['@odata.id']=c['Voltages'][1]['RelatedItem'][1]['@odata.id'].format(rb=rest_base,ch_id=ident)
-    c['PowerSupplies'][0]['@odata.id']=c['PowerSupplies'][0]['@odata.id'].format(rb=rest_base,ch_id=ident)
-    c['PowerSupplies'][0]['RelatedItem'][0]['@odata.id']=c['PowerSupplies'][0]['RelatedItem'][0]['@odata.id'].format(rb=rest_base,ch_id=ident)
-    c['PowerSupplies'][1]['@odata.id']=c['PowerSupplies'][1]['@odata.id'].format(rb=rest_base,ch_id=ident)
-    c['PowerSupplies'][1]['RelatedItem'][0]['@odata.id']=c['PowerSupplies'][1]['RelatedItem'][0]['@odata.id'].format(rb=rest_base,ch_id=ident)
-    c['PowerSupplies'][2]['@odata.id']=c['PowerSupplies'][2]['@odata.id'].format(rb=rest_base,ch_id=ident)
+    c['@odata.context'] = c['@odata.context'].format(**wildcards)
+    c['@odata.id'] = c['@odata.id'].format(**wildcards)
+    c['PowerControl'][0]['@odata.id']=c['PowerControl'][0]['@odata.id'].format(**wildcards)
+    c['PowerControl'][0]['RelatedItem'][0]['@odata.id']=c['PowerControl'][0]['RelatedItem'][0]['@odata.id'].format(**wildcards)
+    c['PowerControl'][0]['RelatedItem'][1]['@odata.id']=c['PowerControl'][0]['RelatedItem'][1]['@odata.id'].format(**wildcards)
+    c['Voltages'][0]['@odata.id']=c['Voltages'][0]['@odata.id'].format(**wildcards)
+    c['Voltages'][0]['RelatedItem'][0]['@odata.id']=c['Voltages'][0]['RelatedItem'][0]['@odata.id'].format(**wildcards)
+    c['Voltages'][0]['RelatedItem'][1]['@odata.id']=c['Voltages'][0]['RelatedItem'][1]['@odata.id'].format(**wildcards)
+    c['Voltages'][1]['@odata.id']=c['Voltages'][1]['@odata.id'].format(**wildcards)
+    c['Voltages'][1]['RelatedItem'][0]['@odata.id']=c['Voltages'][1]['RelatedItem'][0]['@odata.id'].format(**wildcards)
+    c['Voltages'][1]['RelatedItem'][1]['@odata.id']=c['Voltages'][1]['RelatedItem'][1]['@odata.id'].format(**wildcards)
+    c['PowerSupplies'][0]['@odata.id']=c['PowerSupplies'][0]['@odata.id'].format(**wildcards)
+    c['PowerSupplies'][0]['RelatedItem'][0]['@odata.id']=c['PowerSupplies'][0]['RelatedItem'][0]['@odata.id'].format(**wildcards)
+    c['PowerSupplies'][1]['@odata.id']=c['PowerSupplies'][1]['@odata.id'].format(**wildcards)
+    c['PowerSupplies'][1]['RelatedItem'][0]['@odata.id']=c['PowerSupplies'][1]['RelatedItem'][0]['@odata.id'].format(**wildcards)
+    c['PowerSupplies'][2]['@odata.id']=c['PowerSupplies'][2]['@odata.id'].format(**wildcards)
 
     return c

--- a/api_emulator/redfish/templates/thermal.py
+++ b/api_emulator/redfish/templates/thermal.py
@@ -2,11 +2,11 @@
 # Copyright 2016 Distributed Management Task Force, Inc. All rights reserved.
 # License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/Redfish-Interface-Emulator/LICENSE.md
 
-# get_thermal_template()
+# get_thermal_instance()
 
 import copy
 
-_THERMAL_TEMPLATE = \
+_TEMPLATE = \
     {
         "@odata.context": "{rb}$metadata#Chassis/Links/Members/{ch_id}/Links/Thermal/$entity",
         "@odata.id": "{rb}Chassis/{ch_id}/Thermal",
@@ -160,7 +160,7 @@ _THERMAL_TEMPLATE = \
     }
 
 
-def get_thermal_template(rest_base, ch_id):
+def get_thermal_instance(wildcards):
     """
     Returns a formatted template
 
@@ -168,27 +168,27 @@ def get_thermal_template(rest_base, ch_id):
         rest_base - Base URL of the RESTful interface
         ident     - Identifier of the chassis
     """
-    c = copy.deepcopy(_THERMAL_TEMPLATE)
+    c = copy.deepcopy(_TEMPLATE)
 
-    c['@odata.context'] = c['@odata.context'].format(rb=rest_base, ch_id=ch_id)
-    c['@odata.id'] = c['@odata.id'].format(rb=rest_base, ch_id=ch_id)
-    c['Redundancy'][0]['@odata.id']=c['Redundancy'][0]['@odata.id'].format(rb=rest_base,ch_id=ch_id)
-    c['Fans'][0]['@odata.id']=c['Fans'][0]['@odata.id'].format(rb=rest_base,ch_id=ch_id)
-    c['Fans'][1]['@odata.id']=c['Fans'][1]['@odata.id'].format(rb=rest_base,ch_id=ch_id)
-    c['Temperatures'][0]['@odata.id']=c['Temperatures'][0]['@odata.id'].format(rb=rest_base,ch_id=ch_id)
-    c['Temperatures'][0]['RelatedItem'][0]['@odata.id']=c['Temperatures'][0]['RelatedItem'][0]['@odata.id'].format(rb=rest_base,ch_id=ch_id)
-    c['Temperatures'][1]['@odata.id']=c['Temperatures'][1]['@odata.id'].format(rb=rest_base,ch_id=ch_id)
-    c['Temperatures'][1]['RelatedItem'][0]['@odata.id']=c['Temperatures'][1]['RelatedItem'][0]['@odata.id'].format(rb=rest_base,ch_id=ch_id)
-    c['Temperatures'][2]['@odata.id']=c['Temperatures'][2]['@odata.id'].format(rb=rest_base,ch_id=ch_id)
-    c['Temperatures'][2]['RelatedItem'][0]['@odata.id']=c['Temperatures'][2]['RelatedItem'][0]['@odata.id'].format(rb=rest_base,ch_id=ch_id)
-    c['Temperatures'][2]['RelatedItem'][1]['@odata.id']=c['Temperatures'][2]['RelatedItem'][1]['@odata.id'].format(rb=rest_base,ch_id=ch_id)
-    c['Fans'][0]['Redundancy'][0]['@odata.id']=c['Fans'][0]['Redundancy'][0]['@odata.id'].format(rb=rest_base,ch_id=ch_id)
-    c['Fans'][0]['RelatedItem'][0]['@odata.id']=c['Fans'][0]['RelatedItem'][0]['@odata.id'].format(rb=rest_base,ch_id=ch_id)
-    c['Fans'][0]['RelatedItem'][1]['@odata.id']=c['Fans'][0]['RelatedItem'][1]['@odata.id'].format(rb=rest_base,ch_id=ch_id)
-    c['Fans'][1]['Redundancy'][0]['@odata.id']=c['Fans'][1]['Redundancy'][0]['@odata.id'].format(rb=rest_base,ch_id=ch_id)
-    c['Fans'][1]['RelatedItem'][0]['@odata.id']=c['Fans'][1]['RelatedItem'][0]['@odata.id'].format(rb=rest_base,ch_id=ch_id)
-    c['Fans'][1]['RelatedItem'][1]['@odata.id']=c['Fans'][1]['RelatedItem'][1]['@odata.id'].format(rb=rest_base,ch_id=ch_id)
-    c['Redundancy'][0]['RedundancySet'][0]['@odata.id']=c['Redundancy'][0]['RedundancySet'][0]['@odata.id'].format(rb=rest_base,ch_id=ch_id)
-    c['Redundancy'][0]['RedundancySet'][1]['@odata.id']=c['Redundancy'][0]['RedundancySet'][1]['@odata.id'].format(rb=rest_base,ch_id=ch_id)
+    c['@odata.context'] = c['@odata.context'].format(**wildcards)
+    c['@odata.id'] = c['@odata.id'].format(**wildcards)
+    c['Redundancy'][0]['@odata.id']=c['Redundancy'][0]['@odata.id'].format(**wildcards)
+    c['Fans'][0]['@odata.id']=c['Fans'][0]['@odata.id'].format(**wildcards)
+    c['Fans'][1]['@odata.id']=c['Fans'][1]['@odata.id'].format(**wildcards)
+    c['Temperatures'][0]['@odata.id']=c['Temperatures'][0]['@odata.id'].format(**wildcards)
+    c['Temperatures'][0]['RelatedItem'][0]['@odata.id']=c['Temperatures'][0]['RelatedItem'][0]['@odata.id'].format(**wildcards)
+    c['Temperatures'][1]['@odata.id']=c['Temperatures'][1]['@odata.id'].format(**wildcards)
+    c['Temperatures'][1]['RelatedItem'][0]['@odata.id']=c['Temperatures'][1]['RelatedItem'][0]['@odata.id'].format(**wildcards)
+    c['Temperatures'][2]['@odata.id']=c['Temperatures'][2]['@odata.id'].format(**wildcards)
+    c['Temperatures'][2]['RelatedItem'][0]['@odata.id']=c['Temperatures'][2]['RelatedItem'][0]['@odata.id'].format(**wildcards)
+    c['Temperatures'][2]['RelatedItem'][1]['@odata.id']=c['Temperatures'][2]['RelatedItem'][1]['@odata.id'].format(**wildcards)
+    c['Fans'][0]['Redundancy'][0]['@odata.id']=c['Fans'][0]['Redundancy'][0]['@odata.id'].format(**wildcards)
+    c['Fans'][0]['RelatedItem'][0]['@odata.id']=c['Fans'][0]['RelatedItem'][0]['@odata.id'].format(**wildcards)
+    c['Fans'][0]['RelatedItem'][1]['@odata.id']=c['Fans'][0]['RelatedItem'][1]['@odata.id'].format(**wildcards)
+    c['Fans'][1]['Redundancy'][0]['@odata.id']=c['Fans'][1]['Redundancy'][0]['@odata.id'].format(**wildcards)
+    c['Fans'][1]['RelatedItem'][0]['@odata.id']=c['Fans'][1]['RelatedItem'][0]['@odata.id'].format(**wildcards)
+    c['Fans'][1]['RelatedItem'][1]['@odata.id']=c['Fans'][1]['RelatedItem'][1]['@odata.id'].format(**wildcards)
+    c['Redundancy'][0]['RedundancySet'][0]['@odata.id']=c['Redundancy'][0]['RedundancySet'][0]['@odata.id'].format(**wildcards)
+    c['Redundancy'][0]['RedundancySet'][1]['@odata.id']=c['Redundancy'][0]['RedundancySet'][1]['@odata.id'].format(**wildcards)
 
     return c

--- a/api_emulator/resource_dictionary.py
+++ b/api_emulator/resource_dictionary.py
@@ -5,12 +5,14 @@
 # Resource Dictionary
 
 # Variable to store resource dictionary
+import logging
+
 resdict = {}
 
 class ResourceDictionary(object):
 
     def __init__(self):
-        print('Init ResourceDictionary.')
+        logging.info('Init ResourceDictionary.')
 
 
     def get_resource(self, path):

--- a/api_emulator/resource_manager.py
+++ b/api_emulator/resource_manager.py
@@ -110,21 +110,21 @@ class ResourceManager(object):
         g.api.add_resource(ChassisCollectionAPI, '/redfish/v1/Chassis/')
         g.api.add_resource(ChassisAPI,           '/redfish/v1/Chassis/<string:ident>', resource_class_kwargs={'rb': g.rest_base} )
         config = CreateChassis()
-        out = config.__init__(resource_class_kwargs={'rb': g.rest_base} )
+        out = config.__init__(resource_class_kwargs={'rb': g.rest_base, 'linkSystem': "CS_5", 'linkMgr': "BMC"} )
         out = config.put("Chassis2")
 
         # System Collection
         g.api.add_resource(ComputerSystemCollectionAPI, '/redfish/v1/Systems/')
         g.api.add_resource(ComputerSystemAPI,           '/redfish/v1/Systems/<string:ident>', resource_class_kwargs={'rb': g.rest_base} )
         config = CreateComputerSystem()
-        out = config.__init__(resource_class_kwargs={'rb': g.rest_base})
+        out = config.__init__(resource_class_kwargs={'rb': g.rest_base, 'linkChassis': "Chassis2", 'linkMgr': "BMC"})
         out = config.put("CS_5")
 
         # Manager Collection
         g.api.add_resource(ManagerCollectionAPI, '/redfish/v1/Managers/')
         g.api.add_resource(ManagerAPI,           '/redfish/v1/Managers/<string:ident>', resource_class_kwargs={'rb': g.rest_base} )
         config = CreateManager()
-        out = config.__init__(resource_class_kwargs={'rb': g.rest_base})
+        out = config.__init__(resource_class_kwargs={'rb': g.rest_base, 'linkSystem': "CS_5", 'linkChassis': "Chassis2", 'linkInChassis': "Chassis2"})
         out = config.put("BMC")
 
         # PCIe Switch Collection

--- a/api_emulator/resource_manager.py
+++ b/api_emulator/resource_manager.py
@@ -89,7 +89,7 @@ class ResourceManager(object):
         self.time = self.modified
         self.cs_puid_count = 0
 
-        # Loads the static resource into the dictionary
+        # Load the static resources into the dictionary
         self.resource_dictionary = ResourceDictionary()
         self.AccountService = load_static('AccountService', 'redfish', mode, rest_base, self.resource_dictionary)
         self.Registries = load_static('Registries', 'redfish', mode, rest_base, self.resource_dictionary)
@@ -98,7 +98,7 @@ class ResourceManager(object):
         #self.Managers = load_static('Managers', 'redfish', mode, rest_base, self.resource_dictionary)
         #self.EventService = load_static('EventService', 'redfish', mode, rest_base, self.resource_dictionary)
 
-        # Add API for dynamic resource
+        # Attach APIs for dynamic resources
 
         # EventService (singleton)
         g.api.add_resource(EventServiceAPI, '/redfish/v1/EventService/', resource_class_kwargs={'rb': g.rest_base, 'id': "EventService"})


### PR DESCRIPTION
- Support wildcards in Link object paths
- Make Manager and ComputerSystem dynamic.
- By default, instantiate a member for Managers, Chassis and ComputerSystems collections
- Use only flask-restful constructs (remove remnants of flask constructs)
- Add ComputerSystems/{id}/ResetActionInfo and ResetAction resources