### PR TITLE
Fixed typo in populate.py

### DIFF
--- a/infragen/populate.py
+++ b/infragen/populate.py
@@ -90,7 +90,7 @@ def populate(cfg):
                     CreateComputerSystem(
                         resource_class_kwargs={'rb': g.rest_base, 'linkChassis': [chassis], 'linkMgr': bmc}).put(
                         compSys)
-                    create_resources(compsys_template, chassis, 'System', compSys)
+                    create_resources(compsys_template, chassis, 'Systems', compSys)
 
             for rb_template in chassi_template['Links'].get('ResourceBlocks',[]):
                 for j in range(rb_template.get('Count', 1)):


### PR DESCRIPTION
Currently `http://localhost:5000/redfish/v1/Systems/System-1/SimpleStorage` renders the URL `/redfish/v1/System/System-1/SimpleStorage/SAS-CTRL0` for its only member. 
Following the URL results in an 404 as it refers to `.../System/...` instead of `.../Systems/...`