### PR TITLE
Make dynamic and static resource URLs behave the same

### DIFF
--- a/emulator.py
+++ b/emulator.py
@@ -313,7 +313,7 @@ def browse():
 #
 # If any other RESTful request, send to RedfishAPI object for processing. Note: <path:path> specifies any path
 #
-g.api.add_resource(RedfishAPI, '/redfish/v1/', '/redfish/v1/<path:path>/')
+g.api.add_resource(RedfishAPI, '/redfish/v1/', '/redfish/v1/<path:path>')
 
 #
 #


### PR DESCRIPTION
Make dynamic and static resource URLs behave the same, by not requiring a "/" at the end of static resource URLs. This should fix Issue #30 .