### PR TITLE
Correct ChassisCollection properties

### DIFF
--- a/api_emulator/redfish/Chassis_api.py
+++ b/api_emulator/redfish/Chassis_api.py
@@ -126,11 +126,10 @@ class ChassisCollectionAPI(Resource):
             '@odata.id': self.rb + 'Chassis',
             '@odata.type': '#ChassisCollection.1.0.0.ChassisCollection',
             'Name': 'Chassis Collection',
-            'Links': {}
+            'Member@odata.count': len(members),
+            'Members': [{'@odata.id': x['@odata.id']} for
+                        x in list(members.values())]
         }
-        self.config['Links']['Member@odata.count'] = len(members)
-        self.config['Links']['Members'] = [{'@odata.id':x['@odata.id']} for
-                x in list(members.values())]
 
     # HTTP GET
     def get(self):


### PR DESCRIPTION
The ChassisCollection object had its Member@odata.count and Members
properties under a Links property list. Links is not part of the
ChassisCollection schema and these should be direct properties of the
object.

Closes #59