### PR TITLE
Move ServiceRoot services out of Links property

### DIFF
--- a/api_emulator/resource_manager.py
+++ b/api_emulator/resource_manager.py
@@ -235,18 +235,16 @@ class ResourceManager(object):
             'Name': 'Root Service',
             'ServiceVersion': '1.0.0',
             'UUID': self.uuid,
-            'Links': {
-                'Chassis': {'@odata.id': self.rest_base + 'Chassis'},
-                # 'EgResources': {'@odata.id': self.rest_base + 'EgResources'},
-                'Managers': {'@odata.id': self.rest_base + 'Managers'},
-                'TaskService': {'@odata.id': self.rest_base + 'TaskService'},
-                'SessionService': {'@odata.id': self.rest_base + 'SessionService'},
-                'AccountService': {'@odata.id': self.rest_base + 'AccountService'},
-                'EventService': {'@odata.id': self.rest_base + 'EventService'},
-                'Registries': {'@odata.id': self.rest_base + 'Registries'},
-                'Systems': {'@odata.id': self.rest_base + 'Systems'},
-                'CompositionService': {'@odata.id': self.rest_base + 'CompositionService'}
-            }
+            'Chassis': {'@odata.id': self.rest_base + 'Chassis'},
+            # 'EgResources': {'@odata.id': self.rest_base + 'EgResources'},
+            'Managers': {'@odata.id': self.rest_base + 'Managers'},
+            'TaskService': {'@odata.id': self.rest_base + 'TaskService'},
+            'SessionService': {'@odata.id': self.rest_base + 'SessionService'},
+            'AccountService': {'@odata.id': self.rest_base + 'AccountService'},
+            'EventService': {'@odata.id': self.rest_base + 'EventService'},
+            'Registries': {'@odata.id': self.rest_base + 'Registries'},
+            'Systems': {'@odata.id': self.rest_base + 'Systems'},
+            'CompositionService': {'@odata.id': self.rest_base + 'CompositionService'}
         }
 
         return config


### PR DESCRIPTION
References to other services off of the ServiceRoot were placed in a Links property, but according to the spec, this are direct properties of the ServiceRoot object. There is a Links property, but that should only contain references for "Oem" and "Sessions".

Closes: #67 