### PR TITLE
Fixing Unit Tests for Python 3

### DIFF
--- a/unittests.py
+++ b/unittests.py
@@ -59,7 +59,7 @@ class TestRedfishEmulator(unittest.TestCase):
         """
         r = requests.get(url)
         self.assert_status(r, 200, logger)
-	logger.info('PASS: GET of {0} successful (response below)\n {1}'.format(getting, r.text))
+        logger.info('PASS: GET of {0} successful (response below)\n {1}'.format(getting, r.text))
 
     def get_logger(self, name, log_file):
         """
@@ -153,7 +153,7 @@ if __name__ == '__main__':
     parser.add_argument('address', metavar='address', type=str, nargs=1,
                         help='Address to access the emulator')
     args = parser.parse_args()
-    print'Testing interface at:', sys.argv[2]
+    print('Testing interface at:', sys.argv[2])
     suite = unittest.TestLoader().loadTestsFromTestCase(TestRedfishEmulator)
     runner = unittest.TextTestRunner(verbosity=2)
 


### PR DESCRIPTION
This PR fixes issue #73 regarding the Python syntax broken on file unittests.py

- the tabs were replaces by spaces on line 62, making it consistent with the rest of the file

- parenthesis were added to the print on line 152 following Python 3 syntax