### PR TITLE
Fix Status structure format

### DIFF
--- a/api_emulator/redfish/templates/ethernetinterface.py
+++ b/api_emulator/redfish/templates/ethernetinterface.py
@@ -28,7 +28,7 @@ _TEMPLATE = {u'@odata.context': '{rb}$metadata#EthernetInterface.EthernetInterfa
              u'NameServers': ['8.8.8.8'],
              u'PermanentMACAddress': "':'.join(['%02x'%randint(0,255) for x in range(6)])",
              u'SpeedMbps': 10000,
-             u'Status': {'State': {'Health': 'OK', 'State': 'Enabled'}},
+             u'Status': {'Health': 'OK', 'State': 'Enabled'},
              u'VLAN': {u'VLANId': 0}}
 
 

--- a/api_emulator/redfish/templates/memory.py
+++ b/api_emulator/redfish/templates/memory.py
@@ -17,7 +17,7 @@ _TEMPLATE = {'@odata.context': '{rb}$metadata#Memory.Memory',
              'MemoryType': '',  # DRAM,NVDIMM_N,F,P
              'OperatingMemoryModes': [],  # Volatile,PMEM, Block
              'SerialNumber': 'TJ27JXQY',
-             'Status': {'State': {'Health': 'OK', 'State': 'Enabled'}},
+             'Status': {'Health': 'OK', 'State': 'Enabled'},
              'VendorID': 'Generic'}
 
 

--- a/api_emulator/redfish/templates/simplestorage.py
+++ b/api_emulator/redfish/templates/simplestorage.py
@@ -13,14 +13,14 @@ _TEMPLATE = {u'@odata.context': '{rb}$metadata#SimpleStorage.SimpleStorage',
              u'Id': '{storage_id}',
              u'Links': {u'Chassis': {'@odata.id': '{rb}Chassis/{chassis_id}'}},
              u'Name': 'Simple Storage Controller',
-             u'Status': {'State': {'Health': 'OK', 'State': 'Enabled'}},
+             u'Status': {'Health': 'OK', 'State': 'Enabled'},
              u'UefiDevicePath': 'ACPI(PnP)/PCI(1,0)/SAS(0x31000004CF13F6BD,0, SATA)'}
 
 _DEVICE_TEMPLATE = {u'CapacityBytes': 550292684800,
                     u'Manufacturer': 'Generic',
                     u'Model': 'Generic SATA Disk',
                     u'Name': 'Generic Storage Device',
-                    u'Status': {'State': {'Health': 'OK', 'State': 'Enabled'}}}
+                    u'Status': {'Health': 'OK', 'State': 'Enabled'}}
 
 
 def format_storage_template(**kwargs):


### PR DESCRIPTION
An incorrect `State"` top level key was introduced, but these should be
normal `Status` structs.

Closes #76