### PR TITLE
Fix ServiceEnabled boolean properties being returned as string

### DIFF
--- a/api_emulator/redfish/templates/CompositionService.py
+++ b/api_emulator/redfish/templates/CompositionService.py
@@ -19,7 +19,7 @@ _TEMPLATE = \
         "State": "Enabled",
         "Health": "OK"
     },
-    "ServiceEnabled": "true",
+    "ServiceEnabled": True,
     "ResourceBlocks": {
         "@odata.id": "{rb}CompositionService/ResourceBlocks"
     },

--- a/api_emulator/redfish/templates/EventService.py
+++ b/api_emulator/redfish/templates/EventService.py
@@ -19,7 +19,7 @@ _TEMPLATE = \
         "State": "Enabled",
         "Health": "OK"
     },
-    "ServiceEnabled": "true",
+    "ServiceEnabled": True,
     "DeliveryRetryAttempts": 3,
     "DeliveryRetryIntervalSeconds": 60,
     "EventTypesForSubscription": [

--- a/api_emulator/redfish/templates/Manager.py
+++ b/api_emulator/redfish/templates/Manager.py
@@ -27,14 +27,14 @@ _TEMPLATE = \
         "Health": "OK"
     },
     "GraphicalConsole": {
-        "ServiceEnabled": "true",
+        "ServiceEnabled": True,
         "MaxConcurrentSessions": 2,
         "ConnectTypesSupported": [
             "KVMIP"
         ]
     },
     "SerialConsole": {
-        "ServiceEnabled": "true",
+        "ServiceEnabled": True,
         "MaxConcurrentSessions": 1,
         "ConnectTypesSupported": [
             "Telnet",
@@ -43,7 +43,7 @@ _TEMPLATE = \
         ]
     },
     "CommandShell": {
-        "ServiceEnabled": "true",
+        "ServiceEnabled": True,
         "MaxConcurrentSessions": 4,
         "ConnectTypesSupported": [
             "Telnet",


### PR DESCRIPTION
This fixed a few objects that have a boolean ServiceEnabled property but were returning a string value instead.

Closes #78