### PR TITLE
Cast SimpleStorage generated byte count to int

### DIFF
--- a/infragen/populate.py
+++ b/infragen/populate.py
@@ -51,7 +51,8 @@ def create_resources(template, chassis, suffix, suffix_id):
             dsk_id=dsk['Id'].format(dsk_count)
             dsk_count+=1
             resource_ids['SimpleStorage'].append(dsk_id)
-            capacitygb = dsk['Devices'].get('CapacityBytes', 512 * 1024 ** 3) / 1024 ** 3
+            capacitygb = int(dsk['Devices'].get('CapacityBytes',
+                                                512 * 1024 ** 3) / 1024 ** 3)
             drives = dsk['Devices'].get('Count', 1)
             CreateSimpleStorage(rb=g.rest_base, suffix=suffix, storage_id=dsk_id,
                                 suffix_id=suffix_id, chassis_id=chassis, capacitygb=capacitygb,


### PR DESCRIPTION
Calculations of the CapacityBytes for the SimpleStorage Device were causing it to be treated as a float, resulting in the returned size being returned as 549755813888.0. The presence of the decimal point 
causes some clients to treat the value as a floating point value, even though it is a full integer.

Since the spec declares this property as being an integer, this updates the code to cast the calculated size to an int to make sure it is returned as one via the API call.