### PR TITLE
Correct ServiceRoot ServiceVersion to RedfishVersion

### DIFF
--- a/api_emulator/resource_manager.py
+++ b/api_emulator/resource_manager.py
@@ -233,7 +233,7 @@ class ResourceManager(object):
             '@odata.id': self.rest_base,
             'Id': 'RootService',
             'Name': 'Root Service',
-            'ServiceVersion': '1.0.0',
+            'RedfishVersion': '1.0.0',
             'UUID': self.uuid,
             'Chassis': {'@odata.id': self.rest_base + 'Chassis'},
             # 'EgResources': {'@odata.id': self.rest_base + 'EgResources'},


### PR DESCRIPTION
The property name for the service's version was incorrectly reported as
ServiceVersion, but the name of the property in the spec is
RedfishVersion.

Closes: #88