### PR TITLE
Improve handling of composition requests

### DIFF
--- a/api_emulator/redfish/ComputerSystem_api.py
+++ b/api_emulator/redfish/ComputerSystem_api.py
@@ -72,15 +72,16 @@ class ComputerSystemAPI(Resource):
         logging.info('ComputerSystemAPI GET called')
         try:
             # Find the entry with the correct value for Id
-            resp = 404
             if ident in members:
                 conf= members[ident]
                 conf['ProcessorSummary']=self.processor_summary(ident)
                 conf['MemorySummary']=self.memory_summary(ident)
                 resp = conf, 200
+            else:
+                resp = "System " + ident + " not found" , 404
         except Exception:
             traceback.print_exc()
-            resp = INTERNAL_ERROR
+            resp = "Internal Server Error", INTERNAL_ERROR
         return resp
 
     # HTTP PUT
@@ -127,19 +128,21 @@ class ComputerSystemAPI(Resource):
     def delete(self, ident):
         logging.info('ComputerSystemAPI DELETE called')
         try:
-            resp = 404
             if ident in members:
-                if members[ident]['SystemType'] == 'Composed':
-                    # Delete a composed system
-                    resp = DeleteComposedSystem(ident)
-                    resp = 200
-                else:
-                    # Delete a physical system
-                    del(members[ident])
-                    resp = 200
+                #if members[ident]['SystemType'] == 'Composed':
+                #    # Delete a composed system
+                #    resp = DeleteComposedSystem(ident)
+                #    resp = 200
+                #else:
+                # Delete a physical system
+                member = members[ident]
+                del(members[ident])
+                resp = member, 200
+            else:
+                resp = "System " + ident + " not found", 404
         except Exception:
             traceback.print_exc()
-            resp = INTERNAL_ERROR
+            resp = "Internal Server Error", INTERNAL_ERROR
         return resp
 
    
@@ -199,6 +202,7 @@ class ComputerSystemCollectionAPI(Resource):
             config = request.get_json(force=True)
             ok, msg = self.verify(config)
             if ok:
+                config["@odata.id"]= "/redfish/v1/Systems/"+ config['Id']
                 members[config['Id']] = config
                 resp = config, 201
             else:

--- a/api_emulator/redfish/ComputerSystem_api.py
+++ b/api_emulator/redfish/ComputerSystem_api.py
@@ -129,15 +129,14 @@ class ComputerSystemAPI(Resource):
         logging.info('ComputerSystemAPI DELETE called')
         try:
             if ident in members:
-                #if members[ident]['SystemType'] == 'Composed':
-                #    # Delete a composed system
-                #    resp = DeleteComposedSystem(ident)
-                #    resp = 200
-                #else:
-                # Delete a physical system
-                member = members[ident]
-                del(members[ident])
-                resp = member, 200
+                if 'SystemType' in members[ident] and members[ident]['SystemType'] == 'Composed':
+                    # Delete a composed system
+                    resp = DeleteComposedSystem(ident)
+                    resp = 200
+                else:
+                    # Delete a physical system
+                    del(members[ident])
+                    resp = 200
             else:
                 resp = "System " + ident + " not found", 404
         except Exception:

--- a/api_emulator/redfish/ComputerSystem_api.py
+++ b/api_emulator/redfish/ComputerSystem_api.py
@@ -180,6 +180,12 @@ class ComputerSystemCollectionAPI(Resource):
 
     def verify(self, config):
         #TODO: Implement a method to verify that the POST body is valid
+        if 'Id' not in config:
+            return False, "Missing attribute: Id"
+        if 'Links' not in config:
+            return False, "Missing attribute: Links"
+        if 'ResourceBlocks' not in config['Links']:
+            return False, "Missing array: Links['ResourceBlocks']"
         return True,{}
 
     # HTTP POST
@@ -199,7 +205,8 @@ class ComputerSystemCollectionAPI(Resource):
                 resp = msg, 400
         except Exception:
             traceback.print_exc()
-            resp = INTERNAL_ERROR
+            resp = "Internal Server Error", INTERNAL_ERROR
+
         return resp
 
         '''

--- a/test-composed-with-id.json
+++ b/test-composed-with-id.json
@@ -1,0 +1,14 @@
+{
+  "Id":"Composed-1",
+  "Name": "Composed Computer System",
+  "Links": {
+    "ResourceBlocks": [
+      {
+        "@odata.id": "/redfish/v1/CompositionService/ResourceBlocks/Block-1"
+      },
+      {
+        "@odata.id": "/redfish/v1/CompositionService/ResourceBlocks/Block-2"
+      }
+    ]
+  }
+}

--- a/unittests.py
+++ b/unittests.py
@@ -133,15 +133,50 @@ class TestRedfishEmulator(unittest.TestCase):
 
         self.do_gets(params, logger)
 
+    def test_redfish_create_system_status_codes(self):
+        """
+        Unit test to get resource of a system instance
+
+        NOTE: The emulator must be in the redfish mode to run this test
+        """
+        self.log_file = 'test-create-system-status-codes.log'
+        logger = self.get_logger(
+            'test-create-system-status-codes',
+            self.log_file)
+
         with open('test-composed.json') as payload:
             headers = {'Content-Type': 'application/json'}
             r = requests.post(self.url('Systems'), data=payload, headers=headers)
-            self.do_gets([(self.url('Systems/Composed-1'), 'ComposedSystem member')], logger)
+            self.assert_status(r, 400, logger)
+
+        r = requests.get(self.url('Systems/Composed-1'))
+        self.assert_status(r, 404, logger)
 
         # Testing deleting the system instance (expect to fail with 404)
         r = requests.delete(self.url('Systems/Composed-1'))
+        self.assert_status(r, 404, logger)
+
+    def test_redfish_create_system(self):
+        """
+        Unit test to get resource of a system instance
+
+        NOTE: The emulator must be in the redfish mode to run this test
+        """
+        self.log_file = 'test-create-system-status-codes.log'
+        logger = self.get_logger(
+            'test-create-system-status-codes',
+            self.log_file)
+
+        with open('test-composed-with-id.json') as payload:
+            headers = {'Content-Type': 'application/json'}
+            r = requests.post(self.url('Systems'), data=payload, headers=headers)
+            self.assert_status(r, 201, logger)
+
+        r = requests.get(self.url('Systems/Composed-1'))
         self.assert_status(r, 200, logger)
-	    #logger.info('PASS: Unable to delete system instance')
+
+        r = requests.delete(self.url('Systems/Composed-1'))
+        self.assert_status(r, 200, logger)
 
 if __name__ == '__main__':
     #main(sys.argv[2:])


### PR DESCRIPTION
This pull request contains a set of fixes that solve some errors that I found while testing composition requests.

To test composition requests, in  `emulator.py` I set:

```
CONFIG = 'emulator-config_dynamic_populate.json'
```
and followed the documentation to start the server.

### Mismatching response error

The unittests pass:

```
└❯python unittests.py Redfish "localhost:5000"
Testing interface at: localhost:5000
test_redfish_get_serviceroot (__main__.TestRedfishEmulator) ... ok
test_redfish_get_system (__main__.TestRedfishEmulator)
Unit test to get resource of a system instance ... ok

----------------------------------------------------------------------
Ran 2 tests in 0.101s

OK
```

But the server reports a `KeyError` on a missing `Id` in `config`: 

```
INFO:root:ComputerSystemCollectionAPI POST called
Traceback (most recent call last):
  File "/Users/mgazz/workspace/redfish/genz_agent/Redfish-Interface-Emulator/api_emulator/redfish/ComputerSystem_api.py", line 196, in post
    members[config['Id']] = config
KeyError: 'Id'
INFO:werkzeug:127.0.0.1 - - [31/May/2022 13:44:46] "POST /redfish/v1/Systems HTTP/1.1" 200 -
```

The server return `200` while I was expecting `400` as the request does not contain the necessary `Id`.  This is because the methods should return both message and status code, not only status code ([example](https://github.com/DMTF/Redfish-Interface-Emulator/blob/master/api_emulator/redfish/ComputerSystem_api.py#L202))

Similarly, trying to delete `Composed-1`, given that the resource was not created because of the error, I would expect  status code` 404` instead of `200`.  At the same time, the return message contains the expected status code.

```
└❯curl -X DELETE http://localhost:5000/redfish/v1/Systems/Composed-1
404
└❯curl -I -X DELETE http://localhost:5000/redfish/v1/Systems/Composed-1
HTTP/1.1 200 OK
Server: Werkzeug/2.1.2 Python/3.9.12
Date: Tue, 31 May 2022 13:16:07 GMT
Content-Type: application/json
Content-Length: 3
Connection: close
```

### Missing @odata.id

Looking at the code, `KeyError: 'Id’` is expected give that, from the comments [here](https://github.com/DMTF/Redfish-Interface-Emulator/blob/master/api_emulator/redfish/ComputerSystem_api.py#L188), the `Id` should come from the request. In `test-composed.json`, used for the tests, there is no `Id` specified. 

To test the server with a supposedly correct request, I created `test-composed-with-id.json` as following:
```
{
  "Id":"Compose-1",
  "Name": "Composed Computer System",
  "Links": {
    "ResourceBlocks": [
      {
        "@odata.id": "/redfish/v1/CompositionService/ResourceBlocks/Block-1"
      },
      {
        "@odata.id": "/redfish/v1/CompositionService/ResourceBlocks/Block-2"
      }
    ]
  }
}
```

Sending the request as `curl -X POST -H "Content-type: application/json" -d @test-composed-with-id.json http://localhost:5000/redfish/v1/Systems`  the server doesn't report any error and the system is created.

```
INFO:root:ComputerSystemCollectionAPI init called
INFO:root:ComputerSystemCollectionAPI POST called
INFO:werkzeug:127.0.0.1 - - [31/May/2022 13:04:36] "POST /redfish/v1/Systems HTTP/1.1" 201 -
```

However if I now try to fetch the list of systems via `curl http://localhost:5000/redfish/v1/Systems`, I get the following error:
```
ERROR:g:Exception on /redfish/v1/Systems [GET]
Traceback (most recent call last):
  File "/Users/mgazz/.local/share/virtualenvs/Redfish-Interface-Emulator-o_DYV-9b/lib/python3.9/site-packages/flask/app.py", line 1523, in full_dispatch_request
    rv = self.dispatch_request()
  File "/Users/mgazz/.local/share/virtualenvs/Redfish-Interface-Emulator-o_DYV-9b/lib/python3.9/site-packages/flask/app.py", line 1509, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**req.view_args)
  File "/Users/mgazz/.local/share/virtualenvs/Redfish-Interface-Emulator-o_DYV-9b/lib/python3.9/site-packages/flask_restful/__init__.py", line 467, in wrapper
    resp = resource(*args, **kwargs)
  File "/Users/mgazz/.local/share/virtualenvs/Redfish-Interface-Emulator-o_DYV-9b/lib/python3.9/site-packages/flask/views.py", line 83, in view
    self = view.view_class(*class_args, **class_kwargs)  # type: ignore
  File "/Users/mgazz/workspace/redfish/genz_agent/Redfish-Interface-Emulator/api_emulator/redfish/ComputerSystem_api.py", line 163, in __init__
    self.config['Links']['Members'] = [{'@odata.id':x['@odata.id']} for
  File "/Users/mgazz/workspace/redfish/genz_agent/Redfish-Interface-Emulator/api_emulator/redfish/ComputerSystem_api.py", line 163, in <listcomp>
    self.config['Links']['Members'] = [{'@odata.id':x['@odata.id']} for
KeyError: '@odata.id'
```

We are missing `@odata.id` in the internal ComputerSystem resource representation. 

This set of commits aim to solve the problem described above. I modified and extended the unittests to validate that the status codes are the one that we expect. Both for correct and wrong Composition requests.